### PR TITLE
Add Sengled Element Classic (A60) - B22 fitting

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -319,7 +319,7 @@ const mapping = {
     ],
     'GL-C-008': [configurations.light_brightness_colortemp_xy],
     'STSS-MULT-001': [configurations.binary_sensor_contact],
-    'E11-G23': [configurations.light_brightness],
+    'E11-G23/E11-G33': [configurations.light_brightness],
     'AC03645': [configurations.light_brightness_colortemp_xy],
     'AC03641': [configurations.light_brightness],
     'FB56+ZSW05HG1.2': [configurations.switch],


### PR DESCRIPTION
The Sengled Element Classic with Edison fitting (E27) is already defined - model E11-G23.  The same bulb comes with a bayonet fitting (B22) with a slightly different model number - E11-G33.